### PR TITLE
🌻  Fix to trim when text contains surrogate pairs emoji or special text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,20 @@
 A module of trim multibyte string by character width.
 This will work even if contained Unicode, emoji, and surrogate pairs.
 
+## Requirements
+
+This package uses [`Intl.Segmenter`](https://developer.mozilla.org/en-US/docs/Web/API/Intl/Segmenter) to correctly count grapheme clusters, including ZWJ emoji sequences (e.g. `👨‍👩‍👧‍👦`) and combining characters (e.g. `pͪ`).
+
+| Environment | Minimum version |
+|---|---|
+| Node.js | 16+ |
+| Chrome | 87+ |
+| Firefox | 125+ |
+| Safari | 14.1+ |
+
+> [!NOTE]
+> `Intl.Segmenter` is **not** available in older environments. If you need to support them, a polyfill such as [`@formatjs/intl-segmenter`](https://formatjs.io/docs/polyfills/intl-segmenter/) is required.
+
 ## install
 
 ```sh

--- a/src/mbStringWidth.ts
+++ b/src/mbStringWidth.ts
@@ -1,3 +1,7 @@
+const segmenter = new Intl.Segmenter();
+
 type MbStringWidth = (str: string) => number;
 
-export const mbStringWidth: MbStringWidth = (str) => [...str].length;
+export const mbStringWidth: MbStringWidth = (str) => {
+  return [...segmenter.segment(str)].length;
+};

--- a/src/mbTrimWidth.ts
+++ b/src/mbTrimWidth.ts
@@ -1,8 +1,13 @@
+const segmenter = new Intl.Segmenter();
+
 type MbTrimWidth = (str: string, max: number, ellipsis?: string) => string;
 
 export const mbTrimWidth: MbTrimWidth = (str, max, ellipsis) => {
-  const strArray = [...str] as string[];
-  const maxLen = ellipsis ? max - [...ellipsis].length : max;
+  const strArray = [...segmenter.segment(str)].map((s) => s.segment);
+  const ellipsisArray = ellipsis
+    ? [...segmenter.segment(ellipsis)].map((s) => s.segment)
+    : [];
+  const maxLen = ellipsis ? max - ellipsisArray.length : max;
 
   if (strArray.length <= max) {
     return str;
@@ -13,7 +18,7 @@ export const mbTrimWidth: MbTrimWidth = (str, max, ellipsis) => {
   }
 
   if (maxLen <= 0 && ellipsis) {
-    return [...strArray, ...ellipsis].slice(0, max).join('');
+    return [...strArray, ...ellipsisArray].slice(0, max).join('');
   }
 
   return [...strArray.slice(0, maxLen), ellipsis].join('');

--- a/tests/mbTrimWidth.test.ts
+++ b/tests/mbTrimWidth.test.ts
@@ -113,7 +113,7 @@ describe('mbTrimWidth', () => {
     const str = '🌕の夜は𠮷野屋で𩸽を食べたい😇';
 
     test('Check text length', () => {
-      console.log(str, 'length:', str.length);
+      console.log(str, 'length:', str.length, 'mbStringWidth:', mbStringWidth(str));
 
       expect(str.length).toBe(19);
       expect(mbStringWidth(str)).toBe(15);
@@ -129,6 +129,26 @@ describe('mbTrimWidth', () => {
       const trimText = mbTrimWidth(str, 9, '…');
       expect(trimText).toBe('🌕の夜は𠮷野屋で…');
       expect(mbStringWidth(trimText)).toBe(9);
+    });
+  });
+
+  describe('Contains surrogate pairs emoji', () => {
+    const str = '私は👨‍👩‍👧‍👦と🏄🌊と🏕をします';
+
+    test('Check text length', () => {
+      console.log(str, 'length:', str.length, 'mbStringWidth:', mbStringWidth(str));
+
+      expect(mbStringWidth(str)).toBe(12);
+    });
+  });
+
+  describe('Contains surrogate pairs text', () => {
+    const str = 'pͪoͣnͬpͣoͥnͭpͣa͡inͥ';
+
+    test('Check text length', () => {
+      console.log(str, 'length:', str.length, 'mbStringWidth:', mbStringWidth(str));
+
+      expect(mbStringWidth(str)).toBe(10);
     });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2017",
     "module": "commonjs",
-    "lib": ["dom", "dom.iterable", "ES2017"],
+    "lib": ["dom", "dom.iterable", "ES2022"],
     "allowJs": true,
     "checkJs": true,
     "declaration": true,


### PR DESCRIPTION
close #1 

### before

```ts
const text = '私は👨‍👩‍👧‍👦と🏄🌊と🏕をします';
expect(mbTrimWidth(text)).toBe(12);
// Expected: 12
// Received: 18

[…text];
// =>  ["私", "は", "👨", "‍", "👩", "‍", "👧", "‍", "👦", "と", "🏄", "🌊", "と", "🏕", "を", "し", "ま", "す"]

const text = 'pͪoͣnͬpͣoͥnͭpͣa͡inͥ';
expect(mbTrimWidth(text)).toBe(10);
// Expected: 10
// Received: 19

[…text];
// => ["p", "ͪ", "o", "ͣ", "n", "ͬ", "p", "ͣ", "o", "ͥ", "n", "ͭ", "p", "ͣ", "a", "͡", "i", "n", "ͥ"]
```

## after

```ts
const text = '私は👨‍👩‍👧‍👦と🏄🌊と🏕をします';
expect(mbTrimWidth(text)).toBe(12);
// Expected: 12
// Received: 12

const text = 'pͪoͣnͬpͣoͥnͭpͣa͡inͥ';
expect(mbTrimWidth(text)).toBe(10);
// Expected: 10
// Received: 10
```

---

cf.

- https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter
- https://zenn.dev/cybozu_frontend/articles/explore-intl-segmenter