### PR TITLE
🐞  Return 1 character instead of empty string, when trim to 1 width with ellipsis option.

### DIFF
--- a/src/mbTrimWidth.ts
+++ b/src/mbTrimWidth.ts
@@ -8,11 +8,11 @@ export const mbTrimWidth: MbTrimWidth = (str, max, ellipsis) => {
     return str;
   }
 
-  if (maxLen === 0) {
+  if (maxLen === 0 && !ellipsis) {
     return '';
   }
 
-  if (maxLen < 0 && ellipsis) {
+  if (maxLen <= 0 && ellipsis) {
     return [...strArray, ...ellipsis].slice(0, max).join('');
   }
 

--- a/tests/mbTrimWidth.test.ts
+++ b/tests/mbTrimWidth.test.ts
@@ -27,8 +27,8 @@ describe('mbTrimWidth', () => {
       expect(trimText.length).toBe(0);
 
       const trimText2 = mbTrimWidth(str, 1, '…');
-      expect(trimText2).toBe('');
-      expect(trimText2.length).toBe(0);
+      expect(trimText2).toBe('L');
+      expect(trimText2.length).toBe(1);
     });
 
     test('When trim width < ellipsis width, ignore ellipsis', () => {


### PR DESCRIPTION
🐞  Before
```ts
import { mbTrimWidth } from '../src/index';
const str = 'Lorem ipsum dolor sit amet';
const trimText = mbTrimWidth(1, '…');
// => ""
```

🌵  After
```ts
import { mbTrimWidth } from '../src/index';
const str = 'Lorem ipsum dolor sit amet';
const trimText = mbTrimWidth(1, '…');
// => "L"
```